### PR TITLE
Fix progress bar counting and dependency

### DIFF
--- a/ai-contextgen.js
+++ b/ai-contextgen.js
@@ -60,7 +60,7 @@ function listFiles(dir, base, ig, bar) {
     const fullPath = path.join(dir, entry.name);
     const relPath = path.relative(base, fullPath);
     if (ig.ignores(relPath.replace(/\\/g, '/'))) {
-      bar.increment();
+      // Skip ignored files and directories without advancing the progress bar
       continue;
     }
     if (entry.isDirectory()) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "author": "Jérôme WAX",
   "license": "MIT",
   "dependencies": {
-    "@xblaster/ai-contextgen": "^1.0.0",
     "cli-progress": "^3.12.0",
     "commander": "^11.0.0",
     "ignore": "^5.2.0"

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ ai-contextgen --input . --output snapshot.md
 git clone <your-repo-url>
 cd ai-contextgen
 npm install
-node aicontextgen.js --input . --output snapshot.md
+node ai-contextgen.js --input . --output snapshot.md
 ```
 
 ---


### PR DESCRIPTION
## Summary
- ignore skipped files when building the file list
- remove self dependency from `package.json`
- fix README usage example

## Testing
- `node -c ai-contextgen.js`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684aea773ce4832885c56ca7d8994f56