### PR TITLE
Add .ai-ignore support

### DIFF
--- a/.ai-ignore
+++ b/.ai-ignore
@@ -1,0 +1,3 @@
+node_modules
+__aicontextgen.md
+.git

--- a/ai-contextgen.js
+++ b/ai-contextgen.js
@@ -2,7 +2,7 @@
 /*
  * AI-ContextGen
  * Automatically generates a Markdown snapshot of your codebase,
- * respecting .gitignore, ALWAYS skipping .git directory, and skipping large/binary files.
+ * respecting .gitignore and .ai-ignore, ALWAYS skipping .git directory, and skipping large/binary files.
  *
  * Usage:
  *   node AI-ContextGen.js --input ./folder --output snapshot.md
@@ -19,7 +19,7 @@ const program = new Command();
 program
   .option('-i, --input <folder>', 'Input folder to scan', '.')
   .option('-o, --output <filename>', 'Output markdown filename', '__aicontextgen.md')
-  .description('Generate a Markdown snapshot of your project folder for AI context, respecting .gitignore and skipping large/binary files.')
+  .description('Generate a Markdown snapshot of your project folder for AI context, respecting .gitignore, .ai-ignore and skipping large/binary files.')
   .parse(process.argv);
 
 // Show help if no args given
@@ -45,6 +45,11 @@ function getIgnoreFilter(baseDir) {
   const gitignorePath = path.join(baseDir, '.gitignore');
   if (fs.existsSync(gitignorePath)) {
     const content = fs.readFileSync(gitignorePath, 'utf8');
+    ig.add(content.split(/\r?\n/));
+  }
+  const aiIgnorePath = path.join(baseDir, '.ai-ignore');
+  if (fs.existsSync(aiIgnorePath)) {
+    const content = fs.readFileSync(aiIgnorePath, 'utf8');
     ig.add(content.split(/\r?\n/));
   }
   ig.add('.git/'); // <-- Always ignore .git directory
@@ -143,7 +148,7 @@ function filesToMarkdown(files, bar) {
     }
     countEntries(START_DIR);
 
-    console.log(`Scanning files in ${START_DIR} (skipping per .gitignore, .git/, and config)...`);
+    console.log(`Scanning files in ${START_DIR} (skipping per .gitignore, .ai-ignore, .git/, and config)...`);
     const barList = new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic);
     barList.start(totalCount, 0);
     const files = listFiles(START_DIR, START_DIR, ig, barList);

--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,13 @@
 # AI-ContextGen
 
-**AI-ContextGen** is a Node.js CLI utility that generates comprehensive Markdown snapshots of your entire project structure, perfect for providing complete context to AI assistants (ChatGPT, Claude, etc.) while respecting `.gitignore` rules and filtering out binary files.
+**AI-ContextGen** is a Node.js CLI utility that generates comprehensive Markdown snapshots of your entire project structure, perfect for providing complete context to AI assistants (ChatGPT, Claude, etc.) while respecting `.gitignore` and `.ai-ignore` rules and filtering out binary files.
 
 ---
 
 ## ✨ Features
 
 - 📁 **Complete Project Snapshot** - Captures all text files in a structured markdown format
-- 🚫 **Smart Filtering** - Automatically respects `.gitignore` and skips binary/oversized files
+- 🚫 **Smart Filtering** - Automatically respects `.gitignore` and `.ai-ignore` and skips binary/oversized files
 - 📝 **AI-Ready Format** - Generates clean markdown with syntax highlighting for each file
 - ⚡ **Git Integration** - Works seamlessly with Git repositories
 - 🔧 **Configurable** - Command-line options for input/output customization
@@ -88,7 +88,7 @@ The tool creates a structured markdown file like this:
 
 ### What Gets Excluded
 - ❌ Binary files (images, executables, etc.)
-- ❌ Files listed in `.gitignore`
+- ❌ Files listed in `.gitignore` or `.ai-ignore`
 - ❌ Large files (configurable threshold)
 - ❌ Git internal files (unless explicitly needed)
 
@@ -114,7 +114,7 @@ The tool creates a structured markdown file like this:
 
 - **Language**: Node.js / JavaScript
 - **File Detection**: Automatic binary file detection
-- **Git Integration**: Respects `.gitignore` patterns
+- **Git Integration**: Respects `.gitignore` and `.ai-ignore` patterns
 - **Output Format**: Clean markdown with syntax highlighting
 - **Performance**: Efficient file processing with progress indicators
 


### PR DESCRIPTION
## Summary
- rename `.aiignore` to `.ai-ignore`
- ignore entries from `.ai-ignore` the same way as `.gitignore`
- mention new `.ai-ignore` config in docs

## Testing
- `node ai-contextgen.js --help` *(fails: Cannot find module 'ignore')*


------
https://chatgpt.com/codex/tasks/task_e_684aea9db80c8328b8b8c18de8203b8e