### PR TITLE
Fix Windows path separator issue

### DIFF
--- a/src/listFiles.js
+++ b/src/listFiles.js
@@ -13,7 +13,7 @@ function listFiles(dir, base, ig, bar) {
     if (entry.isDirectory()) {
       results = results.concat(listFiles(fullPath, base, ig, bar));
     } else {
-      results.push(relPath);
+      results.push(relPath.replace(/\\/g, '/'));
       if (bar && typeof bar.increment === 'function') {
         bar.increment();
       }


### PR DESCRIPTION
## Summary
- normalize relative paths in listFiles so Windows paths use forward slashes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854f3ad4cd4832884feddfc1c0f0397