### PR TITLE
Improve restore debug and CRLF support

### DIFF
--- a/__tests__/markdownToFiles.test.js
+++ b/__tests__/markdownToFiles.test.js
@@ -38,4 +38,25 @@ describe('markdownToFiles', () => {
     expect(fs.readFileSync('/out/a.txt', 'utf8')).toBe('new content');
     expect(fs.readFileSync('/out/sub/b.txt', 'utf8')).toBe('hello');
   });
+
+  test('handles CRLF line endings', () => {
+    const md = [
+      '# AI-ContextGen Snapshot',
+      '',
+      '---',
+      '',
+      '## `a.txt`',
+      '',
+      '```txt',
+      'content',
+      '```',
+      '',
+      '---',
+      ''
+    ].join('\r\n');
+
+    mock({ '/out': {} });
+    markdownToFiles(md, '/out');
+    expect(fs.readFileSync('/out/a.txt', 'utf8')).toBe('content');
+  });
 });

--- a/ai-contextgen.js
+++ b/ai-contextgen.js
@@ -46,6 +46,7 @@ function snapshotMain(startDir, outputFile) {
     }
   }
   countEntries(startDir);
+  console.log(`Found ${totalCount} files to snapshot.`);
 
   console.log(`Scanning files in ${startDir} (skipping per .gitignore, .ai-ignore, .git/, and config)...`);
   const barList = new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic);
@@ -71,8 +72,13 @@ function restoreMain(markdownPath, outputDir) {
     process.exit(1);
   }
   const content = fs.readFileSync(mdPath, 'utf8');
-  console.log(`Restoring files to ${outputDir}...`);
-  markdownToFiles(content, outputDir);
+  const regex = /## `([^`]+)`\r?\n\r?\n```[^\n]*\r?\n([\s\S]*?)\r?\n```/g;
+  const files = [...content.matchAll(regex)];
+  console.log(`Restoring ${files.length} files to ${outputDir}...`);
+  const bar = new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic);
+  bar.start(files.length, 0);
+  markdownToFiles(content, outputDir, bar);
+  bar.stop();
   console.log('AI-ContextGen: Restoration complete');
 }
 

--- a/src/markdownToFiles.js
+++ b/src/markdownToFiles.js
@@ -1,16 +1,18 @@
 const fs = require('fs');
 const path = require('path');
 
-function markdownToFiles(markdown, targetDir) {
-  const regex = /## `([^`]+)`\n\n```[^\n]*\n([\s\S]*?)\n```/g;
-  let match;
-  while ((match = regex.exec(markdown)) !== null) {
+function markdownToFiles(markdown, targetDir, bar) {
+  const regex = /## `([^`]+)`\r?\n\r?\n```[^\n]*\r?\n([\s\S]*?)\r?\n```/g;
+  const matches = [...markdown.matchAll(regex)];
+  for (const match of matches) {
     const rel = match[1];
     const content = match[2];
     const filePath = path.join(targetDir, rel);
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     fs.writeFileSync(filePath, content, 'utf8');
+    if (bar && typeof bar.increment === 'function') bar.increment();
   }
+  return matches.length;
 }
 
 module.exports = markdownToFiles;


### PR DESCRIPTION
## Summary
- add debug counts for snapshot and restore
- support CRLF line endings in `markdownToFiles`
- show progress bar during restore
- test CRLF handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855231e54e48328b4c0b6c8cbfc0051