### PR TITLE
Fix triple backtick parsing in restore

### DIFF
--- a/__tests__/markdownToFiles.test.js
+++ b/__tests__/markdownToFiles.test.js
@@ -144,4 +144,32 @@ describe('markdownToFiles', () => {
     mock({ '/out': {} });
     expect(() => markdownToFiles(mdWithChecksum, '/out')).toThrow('Global checksum mismatch');
   });
+
+  test('restores file containing triple backticks', () => {
+    const content = 'line1\n```\ncode\n```\nline2';
+    const hash = crypto.createHash('sha256').update(content).digest('hex');
+    const globalHash = crypto
+      .createHash('sha256')
+      .update(`a.md:${hash}\n`)
+      .digest('hex');
+    const md = [
+      '# AI-ContextGen Snapshot',
+      '',
+      '###==AICG_FILE==###',
+      '',
+      `## \`a.md\` (checksum: ${hash})`,
+      '',
+      '```md',
+      content,
+      '```',
+      '',
+      '###==AICG_FILE==###',
+      ''
+    ].join('\n');
+    const mdWithChecksum = md + `\nGlobal checksum: ${globalHash}\n`;
+
+    mock({ '/out': {} });
+    markdownToFiles(mdWithChecksum, '/out');
+    expect(fs.readFileSync('/out/a.md', 'utf8')).toBe(content);
+  });
 });

--- a/ai-contextgen.js
+++ b/ai-contextgen.js
@@ -72,7 +72,7 @@ function restoreMain(markdownPath, outputDir) {
     process.exit(1);
   }
   const content = fs.readFileSync(mdPath, 'utf8');
-  const regex = /## `([^`]+)`(?: \(checksum: ([^\)]+)\))?\r?\n\r?\n```[^\n]*\r?\n([\s\S]*?)\r?\n```/g;
+  const regex = /## `([^`]+)`(?: \(checksum: ([^\)]+)\))?\r?\n\r?\n```[^\n]*\r?\n([\s\S]*?)\r?\n```(?=\r?\n\r?\n###==AICG_FILE==###)/g;
   const files = [...content.matchAll(regex)];
   console.log(`Restoring ${files.length} files to ${outputDir}...`);
   const bar = new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic);

--- a/src/markdownToFiles.js
+++ b/src/markdownToFiles.js
@@ -3,7 +3,7 @@ const path = require('path');
 const crypto = require('crypto');
 
 function markdownToFiles(markdown, targetDir, bar) {
-  const regex = /## `([^`]+)`(?: \(checksum: ([^\)]+)\))?\r?\n\r?\n```[^\n]*\r?\n([\s\S]*?)\r?\n```/g;
+  const regex = /## `([^`]+)`(?: \(checksum: ([^\)]+)\))?\r?\n\r?\n```[^\n]*\r?\n([\s\S]*?)\r?\n```(?=\r?\n\r?\n###==AICG_FILE==###)/g;
   const matches = [...markdown.matchAll(regex)];
   const globalMatch = markdown.match(/Global checksum: ([a-f0-9]+)/);
   const expectedGlobal = globalMatch ? globalMatch[1] : null;


### PR DESCRIPTION
## Summary
- improve markdown parser to look for the closing code fence before the next file separator
- update restore regex
- test restoration of files containing ``` fences

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68765a103a588328a4da913a40080468